### PR TITLE
Display monospaced text inline like bb does

### DIFF
--- a/app/components/board/post/styles.module.css
+++ b/app/components/board/post/styles.module.css
@@ -146,6 +146,7 @@
 .message pre {
   margin: unset;
   font-size: larger;
+  display: inline;
 }
 
 .message img {


### PR DESCRIPTION
BB renders the [m] tag inline:

![bb](https://github.com/spuxx1701/potber-client/assets/4464820/8580cd8d-fdaa-43fa-9006-5cda62674a0a)

This PR also renders monospaced text inline to match existing behavior:

Vorher / Nachdas
![vn](https://github.com/spuxx1701/potber-client/assets/4464820/56434096-b6ec-4a03-8f3a-2fb94ec717cf)
