### PR TITLE
style: minor tweaks for mobile avatars and bookmarked threads

### DIFF
--- a/app/assets/styles/features/quickstart.css
+++ b/app/assets/styles/features/quickstart.css
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: 2px;
 }
 
 .quickstart > hr {
@@ -29,6 +30,7 @@
   border-radius: var(--global-border-radius);
   align-items: stretch;
   justify-content: start;
+  background-color: var(--color-application-background);
 }
 
 .quickstart-item > button:first-child,

--- a/app/components/common/avatar/styles.module.css
+++ b/app/components/common/avatar/styles.module.css
@@ -1,8 +1,7 @@
 :global(.avatar) {
   display: flex;
-  border-radius: 50%;
   overflow: hidden;
-  background-color: var(--color-avatar-background);
+  background-color: unset;
   padding: 0 !important;
   filter: none !important;
   backdrop-filter: none !important;


### PR DESCRIPTION
- Einkreisung der Avatare in Mobile Ansicht, sowie Hintergrundfarbe entfernt

Vorher:
![Bildschirmfoto 2024-07-15 um 16 53 27](https://github.com/user-attachments/assets/7b660ef5-5fff-4cfa-84c3-92234fa5d026)

Nachdas:
![Bildschirmfoto 2024-07-15 um 16 53 46](https://github.com/user-attachments/assets/4816e7de-b5cd-433f-a47a-df7e7ef95334)


- Bookmarked Threads in der Sidebar sind visuell besser getrennt

Vorher:
![Bildschirmfoto 2024-07-15 um 16 44 13](https://github.com/user-attachments/assets/80025867-d087-4474-bf14-4786cb96506f)

Nachdas:
![Bildschirmfoto 2024-07-15 um 16 43 39](https://github.com/user-attachments/assets/15c1dcf7-a17d-460a-a9fc-668a3a8c8da9)


Nur Serviervorschlag. Bin nicht ganz im Repo drin, wenn man das über ein separates Theme auch steuern kann, könnt man das natürlich auch als weiteres Theme anlegen.
