### PR TITLE
style: add poppx theme

### DIFF
--- a/app/assets/styles/global.css
+++ b/app/assets/styles/global.css
@@ -30,6 +30,7 @@
 @import './themes/discord.css';
 @import './themes/purple-haze.css';
 @import './themes/tokyo-night.css';
+@import './themes/poppx.css';
 
 @import './overrides.css';
 

--- a/app/assets/styles/themes/poppx.css
+++ b/app/assets/styles/themes/poppx.css
@@ -1,0 +1,27 @@
+html[data-theme='poppx'],
+html[data-theme='poppx'] * {
+  /* Colors */
+  --color-avatar-background: unset;
+
+  /* Avatar */
+  .avatar {
+    border-radius: 0;
+  }
+
+  @media (max-width: 1200px) {
+    .avatar {
+      width: 60px;
+      height: 60px;
+    }
+  }
+
+  /* Sidebar */
+  .quickstart {
+    gap: 2px;
+  }
+
+  .quickstart-item {
+    border-radius: unset;
+    background-color: var(--color-application-background);
+  }
+}

--- a/app/routes/authenticated/settings/settings.config.ts
+++ b/app/routes/authenticated/settings/settings.config.ts
@@ -70,6 +70,10 @@ export const settingsConfig: Record<
       label: 'Tokyo Night',
       data: Theme['tokyo-night'],
     },
+    {
+      label: 'poppx',
+      data: Theme.poppx,
+    },
   ],
 
   fontSizeOptions: [

--- a/app/services/settings/types.ts
+++ b/app/services/settings/types.ts
@@ -26,6 +26,7 @@ export enum Theme {
   'discord',
   'purple-haze',
   'tokyo-night',
+  'poppx',
 }
 
 export enum LandingPage {


### PR DESCRIPTION
Fügt neues Theme `poppx` hinzu, welches im Prinzip ein Klon von `potber` mit kleinen Tweaks ist.

Features:
- Einkreisung der Avatare in Mobile Ansicht, sowie Hintergrundfarbe entfernt
- Avatare in Mobile sind leicht größer

Vorher:
![Bildschirmfoto 2024-07-15 um 16 53 27](https://github.com/user-attachments/assets/7b660ef5-5fff-4cfa-84c3-92234fa5d026)

Nachdas:
![Bildschirmfoto 2024-07-16 um 09 34 33](https://github.com/user-attachments/assets/e265a51b-d107-4bf5-8caf-add91181debc)


- Bookmarked Threads in der Sidebar sind visuell besser getrennt

Vorher:
![Bildschirmfoto 2024-07-15 um 16 44 13](https://github.com/user-attachments/assets/80025867-d087-4474-bf14-4786cb96506f)

Nachdas:
![Bildschirmfoto 2024-07-15 um 16 43 39](https://github.com/user-attachments/assets/15c1dcf7-a17d-460a-a9fc-668a3a8c8da9)
