### PR TITLE
feat: add panmove gestures to sideboard for better ux

### DIFF
--- a/app/components/sidebar/index.ts
+++ b/app/components/sidebar/index.ts
@@ -74,11 +74,49 @@ export default class SidebarComponent extends Component {
     this.renderer.toggleLeftSidebar(true);
   };
 
+  handlePanmoveInner = ({ gesture }: GestureEvent) => {
+    if (
+      !gesture.touchMoveX ||
+      (this.settings.isRightSidebar() && gesture.touchMoveX < 0) ||
+      (!this.settings.isRightSidebar() && gesture.touchMoveX > 0) ||
+      (gesture.touchMoveX && Math.abs(gesture.touchMoveX) > this.maxWidth)
+    ) {
+      return;
+    }
+
+    this.renderer.dragLeftSidebar(this.maxWidth - Math.abs(gesture.touchMoveX));
+
+    gesture.on('panend', () => {
+      this.renderer.toggleLeftSidebar(false);
+    });
+  };
+
+  handlePanmoveOuter = ({ gesture }: GestureEvent) => {
+    if (
+      !gesture.touchMoveX ||
+      (this.settings.isRightSidebar() && gesture.touchMoveX > 0) ||
+      (!this.settings.isRightSidebar() && gesture.touchMoveX < 0) ||
+      (gesture.touchMoveX && Math.abs(gesture.touchMoveX) > this.maxWidth)
+    ) {
+      return;
+    }
+
+    this.renderer.dragLeftSidebar(Math.abs(gesture.touchMoveX));
+
+    gesture.on('panend', () => {
+      this.renderer.toggleLeftSidebar(false);
+    });
+  };
+
   gestures: Record<string, Gesture[]> = {
     inner: [
       {
         type: 'swipeleft',
         onGesture: this.handleSwipeInner,
+      },
+      {
+        type: 'panmove',
+        onGesture: this.handlePanmoveInner,
       },
     ],
     outer: [
@@ -89,6 +127,10 @@ export default class SidebarComponent extends Component {
       {
         type: 'swipeleft',
         onGesture: this.handleSwipeOuter,
+      },
+      {
+        type: 'panmove',
+        onGesture: this.handlePanmoveOuter,
       },
     ],
   };

--- a/app/services/renderer.ts
+++ b/app/services/renderer.ts
@@ -72,7 +72,7 @@ export default class RendererService extends Service {
 
   /**
    * Updates the sidebar layout. Affects whether the sidebar is rendered on the left
-   * or ride side as well as the position of the sidebar toggle button.
+   * or right side as well as the position of the sidebar toggle button.
    */
   updateSidebarLayout = () => {
     switch (this.settings.sidebarLayout) {
@@ -148,6 +148,16 @@ export default class RendererService extends Service {
       this.settings.getSetting('autoRefreshSidebar')
     )
       this.newsfeed.refresh();
+  };
+
+  /**
+   * Drags the left sidebar according to the current touch move position.
+   * @param touchMoveX Current touch move position on x axis.
+   */
+  dragLeftSidebar = (touchMoveX: number) => {
+    this.setStyleVariable('--sidebar-width', `${touchMoveX}px`);
+    this.setStyleVariable('--sidebar-backdrop-opacity', '0.5');
+    this.setStyleVariable('--nav-controls-opacity', '0');
   };
 
   /*

--- a/app/services/settings.ts
+++ b/app/services/settings.ts
@@ -132,4 +132,11 @@ export default class SettingsService extends Service {
         : 'unset',
     );
   }
+
+  isRightSidebar(): boolean {
+    return (
+      this.sidebarLayout === SidebarLayout.rightTop ||
+      this.sidebarLayout === SidebarLayout.rightBottom
+    );
+  }
 }


### PR DESCRIPTION
Mir war aufgefallen, dass bei aktivierten Sidebar Gestures kein visuelles Feedback implementiert ist, ob man als Nutzer gerade den Swipe/Drag zum Öffnen/Schließen der Sidebar korrekt anwendet.

Hab ein wenig rumgespielt und schließlich mit `panmove` das gewünschte Verhalten nachbilden können. Ähnelt jetzt etwas mehr dem Verhalten vom p0tdroid.

Funktioniert sowohl für linke als auch rechte Sidebar.

Leider konnt ich erstmal nur übern Browser testen, nicht sicher ob das an einem mobilen Endgerät sich genau so verhält, hoffe aber das beste.

Video:

https://github.com/user-attachments/assets/f973ca05-f1e0-400a-b2a7-0139e639d3d5

