### PR TITLE
fix: use default value for max-width on images

### DIFF
--- a/app/components/features/post-form/components/post-title-input/styles.module.css
+++ b/app/components/features/post-form/components/post-title-input/styles.module.css
@@ -10,6 +10,10 @@
   font-size: var(--icon-size-large);
 }
 
+.container button img {
+  max-width: initial;
+}
+
 .container :global(.input-container) {
   flex-grow: 1;
   margin-left: 0.25rem;


### PR DESCRIPTION
Safari skaliert Bilder, auf Grund von `max-width: 100%` scheinbar runter, wenn in einem Element kein Platz vorhanden ist. In diesem Fall war durch die Button-Schriftgröße von `24px` ein "internal" padding von ebenfalls `24px` gesetzt, wodurch das `img`-Element keinen Platz mehr hatte und quasi auf `0%` skaliert wurde. Durch `max-width: initial` wird das verhalten deaktiviert.