### PR TITLE
fix: allow table with attributes

### DIFF
--- a/app/services/content-parser/table.ts
+++ b/app/services/content-parser/table.ts
@@ -4,7 +4,7 @@
  * @returns The output string.
  */
 export function parseTable(input: string) {
-  const TABLE_REGEX = /(?:(\[table\]\s*)(?:\s|\S)*?(\s*\[\/table\]))/gi;
+  const TABLE_REGEX = /(?:(\[table[^\]]*\]\s*)(?:\s|\S)*?(\s*\[\/table\]))/gi;
   if (!TABLE_REGEX.test(input)) return input;
 
   let output = input;

--- a/tests/unit/services/content-parser/_mock/table.ts
+++ b/tests/unit/services/content-parser/_mock/table.ts
@@ -28,4 +28,9 @@ export const tableTagMocks: ContentParserMock[] = [
     [/table]`,
     expected: `<table><tr><td>Ameisenfutter</td><td>JS & Web-Kram (<a href="https://github.com/spuxx1701" target="_blank">GitHub</a>)</td></tr><tr><td>anoX*</td><td>so ziemlich alles (und ABAP, lel)</td></tr><tr><td>Atomsk</td><td>TSQL, DAX, C#</td></tr></table>`,
   },
+  {
+    input: '[table border=0]Hello[||]World[--]Foo[||]Bar[/table]',
+    expected:
+      '<table><tr><td>Hello</td><td>World</td></tr><tr><td>Foo</td><td>Bar</td></tr></table>',
+  },
 ];


### PR DESCRIPTION
Ich hab den RegEx so erweitert, dass nach `table` alles genommen wird, bis zu einem `]`. Da die Attribute nicht genutzt werden, dachte ich wäre es in Ordnung sie einfach komplett zu ignorieren. Ist ein Fix für #310 