### PR TITLE
fix: make URL regex more robust

### DIFF
--- a/tests/unit/services/_mock/post-content.ts
+++ b/tests/unit/services/_mock/post-content.ts
@@ -28,4 +28,8 @@ export const postContentMocks: ContentParserMock[] = [
     input: `[url][img]https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:4xuf4gkbm7cgxqcgpnykzo6e/bafkreihu2a3rwp4hwqhtr6cgf6jejxffhmx5fiw4kpynemm3pulsw5xajy@jpeg[/img][/url]`,
     expected: `<a href="https&#58;//cdn.bsky.app/img/feed_fullsize/plain/did&#58;plc&#58;4xuf4gkbm7cgxqcgpnykzo6e/bafkreihu2a3rwp4hwqhtr6cgf6jejxffhmx5fiw4kpynemm3pulsw5xajy@jpeg" target="_blank"><img src="https&#58;//cdn.bsky.app/img/feed_fullsize/plain/did&#58;plc&#58;4xuf4gkbm7cgxqcgpnykzo6e/bafkreihu2a3rwp4hwqhtr6cgf6jejxffhmx5fiw4kpynemm3pulsw5xajy@jpeg"/></a>`,
   },
+  {
+    input: `[url=https://test.de][img]https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:4xuf4gkbm7cgxqcgpnykzo6e/bafkreihu2a3rwp4hwqhtr6cgf6jejxffhmx5fiw4kpynemm3pulsw5xajy@jpeg[/img][/url]`,
+    expected: `<a href="https&#58;//test.de" target="_blank"><img src="https&#58;//cdn.bsky.app/img/feed_fullsize/plain/did&#58;plc&#58;4xuf4gkbm7cgxqcgpnykzo6e/bafkreihu2a3rwp4hwqhtr6cgf6jejxffhmx5fiw4kpynemm3pulsw5xajy@jpeg"/></a>`,
+  },
 ];


### PR DESCRIPTION
Fix für #232

Ich hab den RegEx so angepasst, dass er alles auf einmal matched. Deswegen hat man dann, je nach Variante, direkt eine URL, oder muss sie sich erst noch über den Inhalt ziehen. Bestehende Tests laufen durch und ich hab den Test um den Case aus #232 erweitert.