### PR TITLE
chore: add dev container to the project

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM node:16 AS build

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -1,0 +1,45 @@
+name: "potber"
+
+services:
+  client:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+
+    volumes:
+    - ../..:/workspaces:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Uncomment the next line to use a non-root user for all processes.
+    # user: vscode
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+    depends_on:
+    - potber-api
+    - potber-auth
+
+  potber-api:
+    image: spuxx/potber-api
+    restart: unless-stopped
+    environment:
+      - APP_PORT=3000
+      - APP_CLIENT_URL=http://localhost:4200
+      - APP_API_URL=http://localhost:3000
+      - SWAGGER_TEST_THREAD_ID=219289
+      - CORS_ALLOWED_ORIGINS=http://localhost:4200
+      - AUTH_JWT_SECRET=imnotarealsecret
+
+  potber-auth:
+    image: spuxx/potber-auth
+    restart: unless-stopped
+    environment:
+      - PORT=5173
+      - ORIGIN=http://localhost:5173
+      - VITE_API_URL=http://potber-api:3000
+      - VITE_API_LOGIN_ENDPOINT=/auth/login
+      - VITE_API_SESSION_ENDPOINT=/auth/session
+
+  

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+    "name": "potber",
+    "dockerComposeFile": "compose.yaml",
+    "service": "client",
+    "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
+      "ghcr.io/devcontainers/features/github-cli:1": {},
+      "ghcr.io/devcontainers/features/git:1": {}
+    },
+  
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "forwardPorts": [
+        4200,
+        "potber-api:3000",
+        "potber-auth:5173"
+    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "lifeart.vscode-ember-unstable",
+                "lifeart.vscode-glimmer-syntax",
+                "esbenp.prettier-vscode"
+            ]
+        }
+    }
+  }
+  

--- a/README.md
+++ b/README.md
@@ -106,8 +106,16 @@ You will need the following things properly installed on your computer.
 
 ### Running / Development
 
+You can either run the application via a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) or without. The advantage of using the dev container is that you do not need to setup or clone the `potber-auth` and `potber-api` repository. Similar as running the application via `npm run start:remote` except that `potber-auth` and `potber-api` are running locally via Docker.
+
+#### Dev Container
+
+You need to have Docker installed on your system and have the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) setup in VSCode. Clone  [potber-api](https://github.com/spuxx1701/potber-api) and open it in VSCode. Click on `Reopen in container`. After finishing the setup, you can start the development server with `npm start` inside of the VSCode terminal. Visit the app at [http://localhost:4200](http://localhost:4200).
+
+#### Without Dev Container
+
 - Clone [potber-api](https://github.com/spuxx1701/potber-api) and start up a local instance.
-- Start up the development server with `npm start` (assuming you also have closed `potber-api` and `potber-auth`). You can also run the client using the remote staging instances of `potber-api` and `potber-auth` via `npm run start:remote`.
+- Start up the development server with `npm start` (assuming you also have cloned `potber-api` and `potber-auth`). You can also run the client using the remote staging instances of `potber-api` and `potber-auth` via `npm run start:remote`.
 - Visit the app at [http://localhost:4200](http://localhost:4200).
 
 #### Linting
@@ -133,7 +141,7 @@ The application can be deployed via [Docker](https://docker.com). The applicatio
 - [staging](Dockerfile.staging)
 - [production](Dockerfile.production)
 
-After building the Docker image, you can run it locally or on a remote host. In case you're curious about how `potber.de` is hosted: Both the [test](https://test.potber.de) and [production](https://potber.de) environments run on a [Flux](https://fluxcd.io)-controlled [MicroK8s](https://microk8s.io) cluster. The infrastructure is documented [here](https://github.com/spuxx1701/flux/tree/master/cluster/apps/potber).
+After building the Docker image, you can run it locally or on a remote host. In case you're curious about how `potber.de` is hosted: Both the [test](https://test.potber.de) and [production](https://potber.de) environments run on a [Flux](https://fluxcd.io)-controlled [MicroK8s](https://microk8s.io) cluster. The infrastructure is documented [here](https://github.com/spuxx1701/flux/tree/main/clusters/constellation/apps/potber).
 
 ## Further Reading / Useful Links
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ You can either run the application via a [Dev Container](https://code.visualstud
 
 #### Dev Container
 
-You need to have Docker installed on your system and have the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) setup in VSCode. Clone  [potber-api](https://github.com/spuxx1701/potber-api) and open it in VSCode. Click on `Reopen in container`. After finishing the setup, you can start the development server with `npm start` inside of the VSCode terminal. Visit the app at [http://localhost:4200](http://localhost:4200).
+You need to have Docker installed on your system and have the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) setup in VSCode. Clone [potber-api](https://github.com/spuxx1701/potber-api) and open it in VSCode. Click on `Reopen in container`. After finishing the setup, you can start the development server with `npm start` inside of the VSCode terminal. Visit the app at [http://localhost:4200](http://localhost:4200).
 
 #### Without Dev Container
 


### PR DESCRIPTION
Mit dem PR wird dem Projekt ein [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) hinzugefügt, was das initiale Setup ein wenig vereinfacht. Wenn mit VSCode das Projekt geöffnet wird, wird im Hintergrund das lokale Projekt in einem Container hochgefahren und gleichzeitig auch der Api und Auth Server. Dadurch hat man dann sofort ein komplettes lokales Setup und kann via `npm start` entwickeln, statt via `npm run start:remote`.

https://github.com/user-attachments/assets/dd5487d4-7ebf-4393-9fc1-12c8f9ac134f

