### PR TITLE
fix(video): add timestamp to video source URL for forcing thumbnail

### DIFF
--- a/app/services/content-parser/video.ts
+++ b/app/services/content-parser/video.ts
@@ -45,7 +45,9 @@ export function parseVideo(input: string, location: Partial<Location>) {
       } else {
         // Other links can be embedded using the <video> tag
         const autoplay = full.includes('play');
-        replacement += `<video src="${url}"${
+        // Seek to 0.001 seconds to prevent the video from showing a black screen
+        // see: https://shj.rip/article/how-to-generate-video-thumbnails-correctly-in-ios-safari.html#media-fragments-uri
+        replacement += `<video src="${url}#t=0.001"${
           autoplay ? ' autoplay playsinline muted loop' : ''
         } controls></video></span>`;
         output = output.replace(match[0], replacement);

--- a/tests/unit/services/_mock/post-content.ts
+++ b/tests/unit/services/_mock/post-content.ts
@@ -11,13 +11,13 @@ export const postContentMocks: ContentParserMock[] = [
     The difference a year makes.`,
     expected: `${createVideoContainer(
       'https&#58;//i.imgur.com/3L4B6FD.mp4',
-      '<video src="https&#58;//i.imgur.com/3L4B6FD.mp4" controls></video>',
+      '<video src="https&#58;//i.imgur.com/3L4B6FD.mp4#t=0.001" controls></video>',
     )}<br/>    Funny? Impressive?<br/>    Both!<br/><br/>    ${createVideoContainer(
       'https&#58;//i.imgur.com/hryNUcS.mp4',
-      '<video src="https&#58;//i.imgur.com/hryNUcS.mp4" controls></video>',
+      '<video src="https&#58;//i.imgur.com/hryNUcS.mp4#t=0.001" controls></video>',
     )}<br/>    ${createVideoContainer(
       'https&#58;//i.imgur.com/MvdqRZa.mp4',
-      '<video src="https&#58;//i.imgur.com/MvdqRZa.mp4" controls></video>',
+      '<video src="https&#58;//i.imgur.com/MvdqRZa.mp4#t=0.001" controls></video>',
     )}<br/>    The difference a year makes.`,
   },
   {

--- a/tests/unit/services/content-parser/_mock/video.ts
+++ b/tests/unit/services/content-parser/_mock/video.ts
@@ -29,7 +29,7 @@ export const videoTagMocks: ContentParserMock[] = [
     [URL]https://www.thedailybeast.com/russian-and-ukrainian-delegates-brawl-over-ukrainian-flag-at-summit-in-turkey?utm_campaign=owned_social&utm_medium=socialflow&via=twitter_page&utm_source=twitter_owned_tdb[/URL]`,
     expected: `${createVideoContainer(
       'https&#58;//video.twimg.com/ext_tw_video/1654245265388322820/pu/vid/480x848/giPQ-V_G5ydzW01q.mp4?tag=12',
-      '<video src="https&#58;//video.twimg.com/ext_tw_video/1654245265388322820/pu/vid/480x848/giPQ-V_G5ydzW01q.mp4?tag=12" controls></video>',
+      '<video src="https&#58;//video.twimg.com/ext_tw_video/1654245265388322820/pu/vid/480x848/giPQ-V_G5ydzW01q.mp4?tag=12#t=0.001" controls></video>',
     )}
     [URL]https://twitter.com/Phil_Lewis_/status/1654245302642126851[/URL]
 
@@ -46,18 +46,18 @@ export const videoTagMocks: ContentParserMock[] = [
     The difference a year makes.`,
     expected: `${createVideoContainer(
       'https&#58;//i.imgur.com/3L4B6FD.mp4',
-      '<video src="https&#58;//i.imgur.com/3L4B6FD.mp4" controls></video>',
+      '<video src="https&#58;//i.imgur.com/3L4B6FD.mp4#t=0.001" controls></video>',
     )}
     Funny? Impressive?
     Both!
 
     ${createVideoContainer(
       'https&#58;//i.imgur.com/hryNUcS.mp4',
-      '<video src="https&#58;//i.imgur.com/hryNUcS.mp4" controls></video>',
+      '<video src="https&#58;//i.imgur.com/hryNUcS.mp4#t=0.001" controls></video>',
     )}
     ${createVideoContainer(
       'https&#58;//i.imgur.com/MvdqRZa.mp4',
-      '<video src="https&#58;//i.imgur.com/MvdqRZa.mp4" controls></video>',
+      '<video src="https&#58;//i.imgur.com/MvdqRZa.mp4#t=0.001" controls></video>',
     )}
     The difference a year makes.`,
   },
@@ -77,28 +77,28 @@ export const videoTagMocks: ContentParserMock[] = [
     [video]https://i.imgur.com/hiUieas.mp4[/video]`,
     expected: `${createVideoContainer(
       'https&#58;//i.imgur.com/MbpN77F.mp4',
-      '<video src="https&#58;//i.imgur.com/MbpN77F.mp4" controls></video>',
+      '<video src="https&#58;//i.imgur.com/MbpN77F.mp4#t=0.001" controls></video>',
     )}
 
 
 
     ${createVideoContainer(
       'https&#58;//i.imgur.com/6zzsiYM.mp4',
-      '<video src="https&#58;//i.imgur.com/6zzsiYM.mp4" controls></video>',
+      '<video src="https&#58;//i.imgur.com/6zzsiYM.mp4#t=0.001" controls></video>',
     )}
 
 
 
     ${createVideoContainer(
       'https&#58;//i.imgur.com/pQWWFJy.mp4',
-      '<video src="https&#58;//i.imgur.com/pQWWFJy.mp4" controls></video>',
+      '<video src="https&#58;//i.imgur.com/pQWWFJy.mp4#t=0.001" controls></video>',
     )}
 
 
 
     ${createVideoContainer(
       'https&#58;//i.imgur.com/hiUieas.mp4',
-      '<video src="https&#58;//i.imgur.com/hiUieas.mp4" controls></video>',
+      '<video src="https&#58;//i.imgur.com/hiUieas.mp4#t=0.001" controls></video>',
     )}`,
   },
   {
@@ -170,7 +170,7 @@ export const videoTagMocks: ContentParserMock[] = [
     input: `[video play]https://i.imgur.com/PWI3g0N.mp4[/video]`,
     expected: `${createVideoContainer(
       'https&#58;//i.imgur.com/PWI3g0N.mp4',
-      '<video src="https&#58;//i.imgur.com/PWI3g0N.mp4" autoplay playsinline muted loop controls></video>',
+      '<video src="https&#58;//i.imgur.com/PWI3g0N.mp4#t=0.001" autoplay playsinline muted loop controls></video>',
     )}`,
   },
 ];


### PR DESCRIPTION
Siehe https://shj.rip/article/how-to-generate-video-thumbnails-correctly-in-ios-safari.html#media-fragments-uri

Damit wird das Laden des ersten Frames forciert.

Fixed #293 