### PR TITLE
fix(modal): prevent scrolling when modal is open

### DIFF
--- a/app/assets/styles/global.css
+++ b/app/assets/styles/global.css
@@ -46,6 +46,11 @@ body {
   width: inherit;
 }
 
+.modal-open {
+  overflow: hidden;
+  position: fixed;
+}
+
 :root {
   font-family: Verdana, Geneva, Tahoma, sans-serif;
   color: var(--color-text-default);

--- a/app/services/modal.ts
+++ b/app/services/modal.ts
@@ -44,6 +44,10 @@ export default class ModalService extends Service {
     return modal as HTMLDialogElement;
   }
 
+  get body() {
+    return document.body as HTMLBodyElement;
+  }
+
   /**
    * Calls a confirm modal.
    * @param options The confirm modal options.
@@ -127,6 +131,7 @@ export default class ModalService extends Service {
     // but it needs to happen asynchronously.
     await sleep(1);
     this.modal.classList.add('show');
+    this.body.classList.add('modal-open');
   }
 
   /**
@@ -135,6 +140,7 @@ export default class ModalService extends Service {
    */
   async close(afterClose?: () => void) {
     this.modal.classList.remove('show');
+    this.body.classList.remove('modal-open');
     await sleep(TIME_TO_DESTROY);
     this.modal.close();
     this.activeModal = {


### PR DESCRIPTION
Wie in #271 im [Kommentar](https://github.com/spuxx1701/potber-client/issues/271#issuecomment-2399488262) erwähnt, schiebt das Onscreen Keyboard in iOS den ganzen Inhalt einmal raus und falsch wieder zurück. 

Durch die `.modal-open` Klasse lässt sich der Body, wenn das Modal offen ist, nicht mehr scrollen und damit verschwindet auch das seltsame iOS-Verhalten. Falls es das Wert ist, gerne mergen, ansonsten rejecten :)

Fixed #271 